### PR TITLE
Switch PHP's default process manager

### DIFF
--- a/setup/web.sh
+++ b/setup/web.sh
@@ -47,6 +47,10 @@ tools/editconf.py /etc/php5/fpm/php.ini -c ';' \
 tools/editconf.py /etc/php5/fpm/php.ini -c ';' \
         default_charset="UTF-8"
 
+# Switch from the dynamic process manager to the ondemand manager
+tools/editconf.py /etc/php5/fpm/pool.d/www.conf -c ';' \
+	pm = ondemand
+
 # Bump up PHP's max_children to support more concurrent connections
 tools/editconf.py /etc/php5/fpm/pool.d/www.conf -c ';' \
 	pm.max_children=8


### PR DESCRIPTION
Changing from dynamic to ondemand lowers the number of idle PHP processes from the default of 3 to 1. PHP automatically scales up the number of processes when required, but kills them after 10 seconds (default). I've seen PHP's memory consumption drop significantly. This should be very helpful for low-end VPS servers. Tested for a couple of months on a VPS with 1 GB and 1 CPU with 5 users. No noticeable negative loading times, but about 15% less RAM usage.

Based on this article: https://ma.ttias.be/a-better-way-to-run-php-fpm/